### PR TITLE
Remove seemingly-accidental dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,5 @@
     "extends": "npm-package-json-lint-config-auto"
   },
   "dependencies": {
-    "type-fest": "^3.5.1"
   }
 }

--- a/test-d/utils/split-words.test-d.ts
+++ b/test-d/utils/split-words.test-d.ts
@@ -1,6 +1,5 @@
 import { expectType } from "tsd";
 import { SplitWords } from "../../source/utils/split-words.js";
-// import { SplitWords } from "type-fest/source/split-words.js";
 
 expectType<SplitWords<"">>([]);
 


### PR DESCRIPTION
This is just a quick fix to remove a dependency that looks accidental. The `type-fest` package was a dependency in the split-words test, though was commented out. It looks like when that happened, it was never removed from dependencies in package.json. Since the readme contains the words "zero dependency," I made the assumption.